### PR TITLE
gif.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1058,8 +1058,8 @@
       }
     },
     "gif.js": {
-      "version": "github:jnordberg/gif.js#a2201f123ed9e5582e57c3d15f5df00c0b8367bd",
-      "from": "github:jnordberg/gif.js"
+      "version": "0.2.0",
+      "resolved": "github:jnordberg/gif.js#a2201f123ed9e5582e57c3d15f5df00c0b8367bd"
     },
     "glob": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webimage",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Takes some html (with whatever you want embedded in it) and changes it into an image via headless Chrome.",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "call-next-tick": "^2.0.1",
     "d3-array": "^2.3.1",
     "d3-queue": "^3.0.7",
-    "gif.js": "github:jnordberg/gif.js",
+    "gif.js": "^0.2.0",
     "jimp": "^0.5.3",
     "lodash.curry": "^4.1.1",
     "playwright": "^1.1.1",


### PR DESCRIPTION
Fixes this error installing from a project that has this dependency

> No matching version found for gif.js@jnordberg-gif.js-master.tar.gz-art-external

cc @jimkang 